### PR TITLE
Add external database support for job statistics storage

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,6 +5,18 @@
 # prometheus server address and port
 PROM_SERVER = "http://vigilant2:8480"
 
+# External MariaDB config used to write intead of writing in slurm db (optional)
+EXTERNAL_DB_TABLE = "job_statistics"
+EXTERNAL_DB_CONFIG = {
+    "enabled": True,  # Set to False to use Slurm DB only
+    "host": "127.0.0.1",
+    "port": 3307,
+    "database": "jobstats",
+    "user": "jobstats",
+    "password": "password",
+#     "config_file": "/path/to/jobstats-db.cnf"
+}
+
 # number of seconds between measurements
 SAMPLING_PERIOD = 30
 

--- a/db_handler.py
+++ b/db_handler.py
@@ -1,0 +1,111 @@
+import MySQLdb
+import sys
+from config import EXTERNAL_DB_CONFIG, EXTERNAL_DB_TABLE
+
+class JobstatsDBHandler:
+    def __init__(self):
+        self.external_db_enabled = EXTERNAL_DB_CONFIG.get("enabled", False)
+        self.external_conn = None
+        
+    def get_external_connection(self):
+        """Get connection to external MariaDB database"""
+        if not self.external_conn:
+            try:
+                if EXTERNAL_DB_CONFIG.get("config_file"):
+                    self.external_conn = MySQLdb.connect(
+                        db=EXTERNAL_DB_CONFIG["database"],
+                        read_default_file=EXTERNAL_DB_CONFIG["config_file"]
+                    )
+                else:
+                    self.external_conn = MySQLdb.connect(
+                        host=EXTERNAL_DB_CONFIG["host"],
+                        port=EXTERNAL_DB_CONFIG["port"],
+                        user=EXTERNAL_DB_CONFIG["user"],
+                        passwd=EXTERNAL_DB_CONFIG["password"],
+                        db=EXTERNAL_DB_CONFIG["database"]
+                    )
+            except Exception as e:
+                print(f"ERROR: Could not connect to external database: {e}", file=sys.stderr)
+                raise
+        return self.external_conn
+    
+    def get_jobstats(self, cluster, jobid):
+        """Retrieve jobstats from external database"""
+        if not self.external_db_enabled:
+            return None
+            
+        try:
+            conn = self.get_external_connection()
+            cur = conn.cursor()
+            
+            query = f"""
+            SELECT admin_comment 
+            FROM {EXTERNAL_DB_TABLE}
+            WHERE cluster = %s AND jobid = %s
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """
+            
+            cur.execute(query, (cluster, jobid))
+            result = cur.fetchone()
+            
+            if result:
+                return result[0]  # Return the admin_comment field
+            return None
+            
+        except Exception as e:
+            print(f"ERROR: Failed to retrieve jobstats from external database: {e}", file=sys.stderr)
+            return None
+    
+    def save_jobstats(self, cluster, jobid, stats, slurm_conn=None):
+        """Save jobstats to external DB and/or Slurm DB based on configuration"""
+        errors = []
+        
+        # If external DB is enabled, only write there
+        if self.external_db_enabled:
+            try:
+                self._save_to_external_db(cluster, jobid, stats)
+            except Exception as e:
+                errors.append(f"External DB error: {e}")
+        # Otherwise, save to Slurm database
+        elif slurm_conn:
+            try:
+                self._save_to_slurm_db(slurm_conn, cluster, jobid, stats)
+            except Exception as e:
+                errors.append(f"Slurm DB error: {e}")
+        else:
+            errors.append("No database connection available")
+        
+        return errors
+    
+    def _save_to_external_db(self, cluster, jobid, stats):
+        """Save to external MariaDB database"""
+        conn = self.get_external_connection()
+        cur = conn.cursor()
+        
+        query = f"""
+        INSERT INTO {EXTERNAL_DB_TABLE} 
+        (cluster, jobid, admin_comment, created_at, updated_at) 
+        VALUES (%s, %s, %s, NOW(), NOW())
+        ON DUPLICATE KEY UPDATE 
+        admin_comment = VALUES(admin_comment),
+        updated_at = NOW()
+        """
+        
+        cur.execute(query, (cluster, jobid, stats))
+        conn.commit()
+    
+    def _save_to_slurm_db(self, conn, cluster, jobid, stats):
+        """Save to Slurm database (existing behavior)"""
+        if not conn:
+            raise Exception("No Slurm database connection provided")
+            
+        cur = conn.cursor()
+        cur.execute(
+            f"UPDATE {cluster}_job_table SET admin_comment = %s WHERE id_job = %s",
+            (stats, jobid)
+        )
+        conn.commit()
+        
+        if cur.rowcount != 1:
+            raise Exception(f"Updated {cur.rowcount} rows instead of 1 for job {jobid}")

--- a/db_handler.py
+++ b/db_handler.py
@@ -1,4 +1,7 @@
-import MySQLdb
+try:
+    import MySQLdb
+except ImportError:
+    MySQLdb = None
 import sys
 from config import EXTERNAL_DB_CONFIG, EXTERNAL_DB_TABLE
 
@@ -9,6 +12,9 @@ class JobstatsDBHandler:
         
     def get_external_connection(self):
         """Get connection to external MariaDB database"""
+        if MySQLdb is None:
+            raise Exception("MySQLdb module not available. Install mysqlclient to use external database functionality.")
+            
         if not self.external_conn:
             try:
                 if EXTERNAL_DB_CONFIG.get("config_file"):

--- a/docs/external-database.md
+++ b/docs/external-database.md
@@ -1,0 +1,141 @@
+# External Database Configuration
+
+This document describes how to configure jobstats to use an external MariaDB/MySQL database instead of storing job statistics in the Slurm database's AdminComment field.
+
+## Overview
+
+By default, jobstats stores job statistics in the Slurm database by updating the `admin_comment` field in the job table. This feature allows you to store jobstats in a separate external MariaDB/MySQL database instead, which can be useful for:
+
+- Separating jobstats data from the Slurm database
+- Easier data analysis and reporting
+- Database backup and maintenance flexibility
+
+## Configuration
+
+### 1. Database Setup
+
+First, create a MariaDB/MySQL database and table to store the jobstats:
+
+```sql
+CREATE DATABASE jobstats;
+USE jobstats;
+
+CREATE TABLE job_statistics (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    cluster VARCHAR(50) NOT NULL,
+    jobid VARCHAR(50) NOT NULL,
+    admin_comment TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_cluster_job (cluster, jobid)
+);
+```
+
+### 2. Python Dependencies
+
+Install the required MySQL client library:
+
+```bash
+# For conda environments
+conda install mysqlclient
+
+# Or using pip
+pip install mysqlclient
+```
+
+### 3. Configuration File
+
+Edit `config.py` to enable external database support:
+
+```python
+EXTERNAL_DB_CONFIG = {
+    "enabled": True,  # Set to True to enable external DB
+    "host": "your-database-host",
+    "port": 3306,
+    "database": "jobstats",
+    "user": "jobstats_user",
+    "password": "your_password",
+    # Alternatively, use a MySQL config file:
+    # "config_file": "/path/to/mysql.cnf"
+}
+```
+
+#### Using MySQL Configuration File (Recommended)
+
+For better security, you can use a MySQL configuration file instead of hardcoding credentials:
+
+```python
+EXTERNAL_DB_CONFIG = {
+    "enabled": True,
+    "database": "jobstats",
+    "config_file": "/etc/jobstats/mysql.cnf"
+}
+```
+
+Create the MySQL config file (`/etc/jobstats/mysql.cnf`):
+```ini
+[client]
+host = your-database-host
+port = 3306
+user = jobstats_user
+password = your_password
+```
+
+### 4. Script Installation
+
+Copy the `store_jobstats.py` script to `/usr/local/bin/` on your Slurm controller:
+
+```bash
+sudo cp store_jobstats.py /usr/local/bin/
+sudo chmod +x /usr/local/bin/store_jobstats.py
+```
+
+### 5. Slurm Configuration
+
+Update your `slurmctldepilog.sh` script. The script will automatically detect the presence of `store_jobstats.py` and use external database storage when available.
+
+## How It Works
+
+### Storage Behavior
+
+- **External DB enabled**: Job statistics are stored only in the external database
+- **External DB disabled**: Job statistics are stored in Slurm's AdminComment field (default behavior)
+
+### Epilog Script Logic
+
+The `slurmctldepilog.sh` script uses the following conditional logic:
+
+1. **If `/usr/local/bin/store_jobstats.py` exists:**
+   - Store jobstats in external database only
+   - Log success/failure for the attempt
+
+2. **If `/usr/local/bin/store_jobstats.py` does NOT exist:**
+   - Use traditional Slurm AdminComment storage (maintains backward compatibility)
+
+This ensures that:
+- Systems without external DB setup continue to work normally
+- Systems with external DB use only the external database (no fallback)
+
+### Data Retrieval
+
+When using the `jobstats` command:
+
+- First checks Slurm AdminComment field for compatibility with existing data
+- If no data found and external DB is enabled → Retrieve from external database
+
+## Migration
+
+### From Slurm AdminComment to External DB
+
+1. Set up the external database and configure `config.py`
+2. Install `store_jobstats.py` script
+3. Future jobs will automatically use the external database
+
+## Troubleshooting
+
+### Common Issues
+
+1. **MySQLdb import error**: Install `mysqlclient` package
+2. **Connection failed**: Check database credentials and network connectivity
+3. **Permission denied**: Ensure `store_jobstats.py` is executable
+4. **Storage handler failed**: Check database permissions and table existence

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
     - Open OnDemand:   setup/ood.md
     - jobstats:        setup/jobstats_command.md
     - Email Reports:   setup/smail.md
+    - External Database: external-database.md
   - Jobstats Tools:
     - Overview:            tools/overview.md
     - Job Defense Shield:  tools/job_defense_shield.md

--- a/slurm/ingest_jobstats.py
+++ b/slurm/ingest_jobstats.py
@@ -5,7 +5,13 @@ import os
 import subprocess
 import sys
 import MySQLdb
+
+# Add the parent directory to Python path to import jobstats modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from jobstats import Jobstats
+from db_handler import JobstatsDBHandler
+import config as c
 
 DB='slurm_acct_db'
 DEVNULL = open(os.devnull, 'w')
@@ -29,25 +35,64 @@ def get_jobs_to_process(conn, cluster, num):
     # tres_req will contain something like 1=8,2=65536,4=1,5=24,1001=2 so store ,1001= as string to search for
     gpuid = ",%d=" % get_gpu_tres(conn)
     cur = conn.cursor()
-    cur.execute('select id_job,time_start,time_end,state,tres_req from %s_job_table where admin_comment IS NULL and time_start > 0 and time_end > 0 ORDER BY id_job DESC LIMIT %d' % (cluster, num))
-    jobs = {}
-    for id_job,start,end,state,tres in cur.fetchall():
-        if gpuid in tres and (gpuid+"0") not in tres:
-            gpus = True
-        else:
-            gpus = False
-        jobs[id_job] = { "start": start, "end": end, "state": state, "tres": tres, "gpus": gpus }
+    
+    # If external DB is enabled, check if jobstats exist
+    if c.EXTERNAL_DB_CONFIG.get("enabled", False):
+        # Get jobs without jobstats
+        db_handler = JobstatsDBHandler()
+        try:
+            ext_conn = db_handler.get_external_connection()
+            ext_cur = ext_conn.cursor()
+            
+            # Get job IDs that already exist in external DB
+            ext_cur.execute(f'SELECT DISTINCT jobid FROM {c.EXTERNAL_DB_TABLE} WHERE cluster = %s', (cluster,))
+            existing_external_jobs = set(str(row[0]) for row in ext_cur.fetchall())
+            
+            # Get all recent jobs from Slurm DB
+            cur.execute('select id_job,time_start,time_end,state,tres_req,admin_comment from %s_job_table where time_start > 0 and time_end > 0 ORDER BY id_job DESC LIMIT %d' % (cluster, num))
+            jobs = {}
+            for id_job,start,end,state,tres,admin_comment in cur.fetchall():
+                # Skip if job already has stats in either Slurm admin_comment or external DB
+                if admin_comment is not None or str(id_job) in existing_external_jobs:
+                    continue
+                    
+                if gpuid in tres and (gpuid+"0") not in tres:
+                    gpus = True
+                else:
+                    gpus = False
+                jobs[id_job] = { "start": start, "end": end, "state": state, "tres": tres, "gpus": gpus }
+            
+            ext_conn.close()
+            
+        except Exception as e:
+            print(f"ERROR: Failed to check external database: {e}")
+            sys.exit(1)  # Fail instead of falling back to Slurm DB
+    else:
+        # only check Slurm DB
+        cur.execute('select id_job,time_start,time_end,state,tres_req from %s_job_table where admin_comment IS NULL and time_start > 0 and time_end > 0 ORDER BY id_job DESC LIMIT %d' % (cluster, num))
+        jobs = {}
+        for id_job,start,end,state,tres in cur.fetchall():
+            if gpuid in tres and (gpuid+"0") not in tres:
+                gpus = True
+            else:
+                gpus = False
+            jobs[id_job] = { "start": start, "end": end, "state": state, "tres": tres, "gpus": gpus }
+    
     return jobs
 
 def save_jobstats(conn, cluster, jobid, stats):
-    try:
-        cur = conn.cursor()
-        cur.execute("UPDATE %s_job_table set admin_comment = '%s' WHERE id_job=%s" % (cluster, stats, jobid))
-        conn.commit()
-        if cur.rowcount != 1:
-            print("ERROR: Tried to update jobid %s admin_comment with %s but updated %d rows." % (jobid, stats, cur.rowcount))
-    except Error as e:
-        print("ERROR: Failed to update jobid %s admin_comment with %s, got error: %s" %(jobid,stats,e))
+    db_handler = JobstatsDBHandler()
+    
+    # If external DB is enabled, only write there
+    if c.EXTERNAL_DB_CONFIG.get("enabled", False):
+        print("writing to external db")
+        errors = db_handler.save_jobstats(cluster, jobid, stats, None)  # Don't pass slurm_conn
+    else:
+        print("writing to slurm db")
+        errors = db_handler.save_jobstats(cluster, jobid, stats, conn)
+    
+    if errors:
+        print(f"ERROR: Failed to save jobstats for job {jobid}: {'; '.join(errors)}")
 
 def get_current_jobs(cluster):
     cmd = ["/usr/bin/squeue", "--noheader", "-M", cluster, "-o","%A" ]
@@ -58,7 +103,7 @@ def process_job(conn, cluster, jobid, details):
     try:
         diff = details['end'] - details['start']
         if diff > 59:
-            stats = JobStats(jobid=jobid, jobidraw=jobid, start=details['start'], end=details['end'], gpus=details['gpus'], cluster=cluster)
+            stats = Jobstats(jobid=jobid, jobidraw=jobid, start=details['start'], end=details['end'], gpus=details['gpus'], cluster=cluster)
             save_stats = "JS1:%s" % stats.report_job_json(encode=True)
         else:
             save_stats = "JS1:Short"

--- a/slurm/ingest_jobstats.py
+++ b/slurm/ingest_jobstats.py
@@ -4,7 +4,10 @@ import argparse
 import os
 import subprocess
 import sys
-import MySQLdb
+try:
+    import MySQLdb
+except ImportError:
+    MySQLdb = None
 
 # Add the parent directory to Python path to import jobstats modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/slurm/slurmctldepilog.sh
+++ b/slurm/slurmctldepilog.sh
@@ -16,15 +16,23 @@ if [ $ERR = 0 ]; then
 	if [[ $STATS =~ ^(Short|None|H4s) ]]; then
 		logger "SlurmctldEpilog[$INTERNAL_JOBID]: Success with output $STATS"
 
+		# Check if external database storage is configured
 		if [ -f "/usr/local/bin/store_jobstats.py" ]; then
+			# Use external database storage only
 			OUT="`/usr/local/bin/store_jobstats.py --cluster=${SLURM_CLUSTER_NAME:-unknown} --jobid=$INTERNAL_JOBID --stats="JS1:$STATS" 2>&1`"
 			if [ $? != 0 ]; then
-				logger "SlurmctldEpilog[$INTERNAL_JOBID]: Storage handler failed with $OUT - external DB integration required"
+				logger "SlurmctldEpilog[$INTERNAL_JOBID]: External storage failed with $OUT"
 			else
-				logger "SlurmctldEpilog[$INTERNAL_JOBID]: Successfully stored with store_jobstats.py"
+				logger "SlurmctldEpilog[$INTERNAL_JOBID]: Successfully stored with external database"
 			fi
 		else
-			logger "SlurmctldEpilog[$INTERNAL_JOBID]: store_jobstats.py not found - external DB integration required"
+			# No external storage configured, use AdminComment in slurm db
+			OUT="`sacctmgr -i update job where jobid=$INTERNAL_JOBID set AdminComment=JS1:$STATS 2>&1`"
+			if [ $? != 0 ]; then
+				logger "SlurmctldEpilog[$INTERNAL_JOBID]: Errored out when storing AdminComment with $OUT"
+			else
+				logger "SlurmctldEpilog[$INTERNAL_JOBID]: Successfully stored in AdminComment"
+			fi
 		fi
 	else
 		logger "SlurmctldEpilog[$INTERNAL_JOBID]: Apparent success but invalid output $STATS"

--- a/store_jobstats.py
+++ b/store_jobstats.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import os
+import MySQLdb
+
+# Add the parent directory to Python path to import jobstats modules
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from db_handler import JobstatsDBHandler
+from config import EXTERNAL_DB_CONFIG
+
+def main():
+    parser = argparse.ArgumentParser(description="Store jobstats to external and/or Slurm database")
+    parser.add_argument("--cluster", required=True, help="Cluster name")
+    parser.add_argument("--jobid", required=True, help="Job ID")
+    parser.add_argument("--stats", required=True, help="Job statistics")
+    
+    args = parser.parse_args()
+    
+    db_handler = JobstatsDBHandler()
+    
+    # Only use external DB when enabled
+    if not EXTERNAL_DB_CONFIG.get("enabled", False):
+        print("ERROR: External database is not enabled. This script requires external DB configuration.", file=sys.stderr)
+        sys.exit(1)
+    
+    # Save to external database
+    errors = db_handler.save_jobstats(args.cluster, args.jobid, args.stats, None)
+    
+    if errors:
+        print(f"Errors occurred: {'; '.join(errors)}", file=sys.stderr)
+        sys.exit(1)
+    
+    print("Successfully stored jobstats")
+
+if __name__ == "__main__":
+    main()

--- a/store_jobstats.py
+++ b/store_jobstats.py
@@ -2,7 +2,10 @@
 import argparse
 import sys
 import os
-import MySQLdb
+try:
+    import MySQLdb
+except ImportError:
+    MySQLdb = None
 
 # Add the parent directory to Python path to import jobstats modules
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -20,9 +23,14 @@ def main():
     
     db_handler = JobstatsDBHandler()
     
-    # Only use external DB when enabled
+    # Check if external DB is enabled and available
     if not EXTERNAL_DB_CONFIG.get("enabled", False):
-        print("ERROR: External database is not enabled. This script requires external DB configuration.", file=sys.stderr)
+        print("ERROR: External database is not enabled in config.py", file=sys.stderr)
+        sys.exit(1)
+    
+    # Check if MySQLdb is available
+    if MySQLdb is None:
+        print("ERROR: MySQLdb module not available. Install mysqlclient to use external database functionality.", file=sys.stderr)
         sys.exit(1)
     
     # Save to external database


### PR DESCRIPTION
This PR adds support for storing job statistics in an external MariaDB/MySQL database instead of the Slurm database's AdminComment field. This way institutions that dont want an external program to be wirting to slurmdb can still use jobstats.

When enabled via config, all job statistics are written exclusively to the external database with no fallback to Slurm. The jobstats command automatically retrieves data from the configured source.

Configuration is simple - just add the external database connection details to config.py and set enabled=True. Backward compatibility is maintained when the feature is disabled.