### PR TITLE
Fix/ingest external db

### DIFF
--- a/docs/setup/external-database.md
+++ b/docs/setup/external-database.md
@@ -126,6 +126,14 @@ When using the `jobstats` command:
 - the Slurm `AdminComment` field is checked for compatibility with existing data
 - if no data found and external DB is enabled then retrieve from external database
 
+### Catching Up Missing Data
+
+If you need to catch up on storing statistics for past jobs or if the epilog fails, you can run the `ingest_jobstats` script.
+
+When an external database is enabled:
+- `jobs_with_no_data.py` will query your external database to determine which jobs still need data, rather than checking the Slurm database's `AdminComment`.
+- `ingest_jobstats` will automatically use `store_jobstats.py` if it exists in `/usr/local/bin/` to write the missing data to the external database.
+
 ## Migration
 
 From Slurm `AdminComment` to External DB:

--- a/slurm/ingest_jobstats
+++ b/slurm/ingest_jobstats
@@ -40,11 +40,20 @@ for i in $(/usr/local/sbin/jobs_with_no_data.py -c $CLUSTER $DAYS $MAXJOBS); do
 	ERR=$?
 	if [ $ERR = 0 ]; then
 		if [[ $STATS =~ ^(Short|None|H4s) ]]; then
-			OUT="`sacctmgr -i update job where jobid=$i set AdminComment=JS1:$STATS 2>&1`"
-			if [ $? != 0 ]; then
-				echo "Job ${i}: Errored out when storing AdminComment with $OUT" >&2
-			elif [ -n $VERBOSE ]; then
-				echo "Job ${i}: Successfully updated job with output ${STATS}"
+			if [ -f "/usr/local/bin/store_jobstats.py" ]; then
+				OUT="`/usr/local/bin/store_jobstats.py --cluster=$CLUSTER --jobid=$i --stats="JS1:$STATS" 2>&1`"
+				if [ $? != 0 ]; then
+					echo "Job ${i}: Errored out when storing external DB jobstats with $OUT" >&2
+				elif [ -n "$VERBOSE" ]; then
+					echo "Job ${i}: Successfully updated external jobstats with output ${STATS}"
+				fi
+			else
+				OUT="`sacctmgr -i update job where jobid=$i set AdminComment=JS1:$STATS 2>&1`"
+				if [ $? != 0 ]; then
+					echo "Job ${i}: Errored out when storing AdminComment with $OUT" >&2
+				elif [ -n "$VERBOSE" ]; then
+					echo "Job ${i}: Successfully updated job with output ${STATS}"
+				fi
 			fi
 		else
 			echo "Job ${i}: Apparent success but invalid output $STATS" >&2

--- a/slurm/jobs_with_no_data.py
+++ b/slurm/jobs_with_no_data.py
@@ -7,6 +7,13 @@ import sys
 import MySQLdb
 import time
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import config as c
+
+# Only import db_handler if external db is enabled
+if c.EXTERNAL_DB_CONFIG.get("enabled", False):
+    from db_handler import JobstatsDBHandler
+
 DB='slurm_acct_db'
 DEVNULL = open(os.devnull, 'w')
 
@@ -27,22 +34,40 @@ def get_jobs_to_process(conn, cluster, num, days):
         time_end = 0
     else:
         time_end = int(time.time() - 24*days*60*60)
-    running_jobs = get_current_jobs(cluster)
+    running_jobs = set(get_current_jobs(cluster))
+    
+    external_db_enabled = c.EXTERNAL_DB_CONFIG.get("enabled", False)
+    existing_jobs = set()
+    
+    if external_db_enabled:
+        db_handler = JobstatsDBHandler()
+        ext_conn = db_handler.get_external_connection()
+        ext_cur = ext_conn.cursor()
+        ext_cur.execute(f"SELECT jobid FROM {c.EXTERNAL_DB_TABLE} WHERE cluster = %s", (cluster,))
+        existing_jobs = set([str(row[0]) for row in ext_cur.fetchall()])
+        
     cur = conn.cursor()
     cur.execute(f"select id_job,id_array_job,id_array_task from {cluster}_job_table where admin_comment IS NULL and time_start > 0 and time_end > {time_end} ORDER BY id_job DESC LIMIT {num}")
+
     jobs = []
     for id_job,id_array_job,id_array_task in cur.fetchall():
-        if id_job in running_jobs:
+        if str(id_job) in running_jobs:
             continue
         # An array job looks like id_job=2666514, id_array_job=2666501, id_array_task=9
         # Non array job looke like id_job=2666518, id_array_job=0, id_array_task=4294967294
         if id_array_job != 0:
             if id_array_task == 4294967294:
                 warn(f"Ignoring array job {id_job}, array job id {id_array_job} with array task = {id_array_task}")
-            else:
-                jobs.append(f"{id_array_job}_{id_array_task}")
+                continue
+            job_id_str = f"{id_array_job}_{id_array_task}"
         else:
-            jobs.append(id_job)
+            job_id_str = str(id_job)
+
+        if external_db_enabled and job_id_str in existing_jobs:
+            continue
+
+        jobs.append(job_id_str)
+            
     return jobs
 
 def run_processing(cluster, num, days):


### PR DESCRIPTION
Fixes #44 makes `ingest_jobstats` work with external DB: `jobs_with_no_data.py`  now checks the external `job_statistics` table and respects `--num`, and `ingest_jobstats` will call `store_jobstats.py`  when present.