### PR TITLE
Fix/gpu tres and syspath

### DIFF
--- a/jobstats.py
+++ b/jobstats.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import re
 import subprocess
 import sys
 import time
@@ -239,10 +240,10 @@ class Jobstats:
                 self.error(msg)
 
         self.gpus = 0
-        if self.tres is not None and 'gres/gpu=' in self.tres and 'gres/gpu=0,' not in self.tres:
-            for part in self.tres.split(","):
-                if "gres/gpu=" in part:
-                    self.gpus = int(part.split("=")[-1])
+        if self.tres is not None:
+            # Match both untyped (gres/gpu=N) and typed (gres/gpu:TYPE=N) GPU allocations
+            gpu_matches = re.findall(r'gres/gpu(?::[^=,]+)?=(\d+)', self.tres)
+            self.gpus = sum(int(n) for n in gpu_matches)
  
         if self.timelimitraw.isnumeric():
             self.timelimitraw = int(self.timelimitraw)

--- a/store_jobstats.py
+++ b/store_jobstats.py
@@ -7,8 +7,8 @@ try:
 except ImportError:
     MySQLdb = None
 
-# Add the parent directory to Python path to import jobstats modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add the script's own directory to Python path to import jobstats modules
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from db_handler import JobstatsDBHandler
 from config import EXTERNAL_DB_CONFIG


### PR DESCRIPTION
Dear jobstats team,

Thanks for creating this package. I found it very useful for small HPC facilities like ours to have a better overview of the nature of their user's workloads and spot low resource job utilization. 

We have started testing the package and we found two bugs that might probably  got unnoticed till now.

1.  The regex used to identify GPU resource allocation in job was not ready for the case of **typed** GPU:
      ```bash
      (linux-utils) valerio@somatestlogin01 ~/jobstats (somatest-gpu-debug) $ scontrol show config | grep AccountingStorageTRES
      AccountingStorageTRES   = cpu,mem,energy,node,billing,fs/disk,vmem,pages,gres/gpu:nvidia_geforce_rtx_2080_ti
      ```
2.  There is a bug in forming the `sys.path` when the package is installed under `/usr/local`:
      ```
      # Change this line in /usr/local/bin/store_jobstats.py:
      sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
      # To this:
      sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'jobstats'))
      # Which resolves to: /usr/local/jobstats ✓
      ```
Please let me know if you require some additional information/details.

Best,
 Omar