### PR TITLE
Fix/issue 47 external db array and ingest

### DIFF
--- a/docs/setup/external-database.md
+++ b/docs/setup/external-database.md
@@ -25,7 +25,7 @@ USE jobstats;
 CREATE TABLE job_summary (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     cluster VARCHAR(40) NOT NULL,
-    jobid BIGINT NOT NULL,
+    jobid VARCHAR(50) NOT NULL,
     admin_comment LONGTEXT,
     total_time DOUBLE DEFAULT NULL,
     gpus INT DEFAULT NULL,

--- a/docs/setup/external-database.md
+++ b/docs/setup/external-database.md
@@ -166,6 +166,10 @@ From Slurm `AdminComment` to External DB:
 2. Install the `store_jobstats.py` script
 3. Future jobs will automatically use the external database
 
+## Current Limitation
+
+When external database storage is enabled, `ingest_jobstats` does not backfill missed historical jobs into the external database. It exits without writing `AdminComment` in the Slurm database so that external-only storage remains consistent. At present, only the `slurmctld` epilog path writes new completions into the external database.
+
 ## Structured Schema Benefits
 
 The new schema splits job statistics into explicit columns and related tables, enabling:
@@ -224,4 +228,3 @@ CREATE TABLE job_statistics (
 ```
 
 This schema stored all job metrics in a compressed blob in the `admin_comment` field. The new structured schema decodes and stores metrics in explicit columns for easier querying. The `admin_comment` field is retained in `job_summary` for backward compatibility.
-

--- a/docs/setup/jobstats_command.md
+++ b/docs/setup/jobstats_command.md
@@ -28,7 +28,7 @@ The necessary software can be installed as follows:
     (.venv) $ pip3 install requests blessed
     ``` 
 
-The files needed to run the `jobstats` command are available in the <a href="https://github.com/PrincetonUniversity/jobstats" target="_blank">Jobstats GitHub repository</a>.
+The core files needed to run the `jobstats` command are available in the <a href="https://github.com/PrincetonUniversity/jobstats" target="_blank">Jobstats GitHub repository</a>.
 
 First, store the files in a path such as:
 
@@ -38,6 +38,11 @@ config.py
 jobstats
 jobstats.py
 output_formatters.py
+```
+
+If you are using external MariaDB storage, also install:
+
+```
 db_handler.py
 store_jobstats.py
 ```

--- a/docs/setup/jobstats_command.md
+++ b/docs/setup/jobstats_command.md
@@ -28,7 +28,7 @@ The necessary software can be installed as follows:
     (.venv) $ pip3 install requests blessed
     ``` 
 
-The four files needed to run the `jobstats` command are available in the <a href="https://github.com/PrincetonUniversity/jobstats" target="_blank">Jobstats GitHub repository</a>.
+The files needed to run the `jobstats` command are available in the <a href="https://github.com/PrincetonUniversity/jobstats" target="_blank">Jobstats GitHub repository</a>.
 
 First, store the files in a path such as:
 
@@ -38,6 +38,8 @@ config.py
 jobstats
 jobstats.py
 output_formatters.py
+db_handler.py
+store_jobstats.py
 ```
 
 Then create a symlink in `/usr/local/bin` pointing to the executable:
@@ -78,7 +80,6 @@ Job summary statistics can be stored in the Slurm database or one can use an ext
 ```python
 # if using Slurm database then include the lines below with "enabled": False
 # if using MariaDB then set "enabled": True
-EXTERNAL_DB_TABLE = "job_statistics"
 EXTERNAL_DB_CONFIG = {
     "enabled": False,  # set to True to use the external db for storing stats
     "host": "127.0.0.1",
@@ -90,7 +91,17 @@ EXTERNAL_DB_CONFIG = {
 }
 ```
 
-If you wish to use MariaDB then see [External Database](external-database.md).
+If you wish to use MariaDB then see [External Database](external-database.md). That page is the authoritative setup guide for schema creation, `store_jobstats.py` installation, and external DB behavior.
+
+If you use external MariaDB storage then also install `store_jobstats.py` in `/usr/local/bin`:
+
+```bash
+$ ln -s /usr/local/jobstats/store_jobstats.py /usr/local/bin/store_jobstats.py
+```
+
+When external DB is enabled, `store_jobstats.py` writes only to the external database. It does not fall back to writing `AdminComment` in the Slurm database.
+
+For complete external database deployment instructions, continue with [External Database](external-database.md).
 
 The number of seconds between measurements by the exporters on the compute nodes:
 

--- a/docs/setup/summaries.md
+++ b/docs/setup/summaries.md
@@ -15,6 +15,8 @@ The impact on the database size due to this depends on job sizes. For an institu
 
 For processing old jobs where the `slurmctld` epilog script did not run or for jobs where it failed, there is a per cluster ingest Jobstats service. This is a combination of a Python-based script `jobs_with_no_data.py` that returns a list of recent jobs with an empty AdminComment and a bash script `ingest_jobstats` that uses that utility to process those jobs and set AdminComment. Since the `jobs_with_no_data.py` needs db access it is easiest to run this on the `slurmdbd` host, either as a cron or a `systemd` timer and service. These scripts (`ingest_jobstats` and 'jobs_with_no_data.py') and `systemd` timer and service units are in the `slurm` directory of the <a href="https://github.com/PrincetonUniversity/jobstats/tree/main/slurm" target="_blank">Jobstats GitHub repository</a>.
 
+When external MariaDB storage is enabled, `ingest_jobstats` skips `AdminComment` backfill instead of writing into the Slurm database. This preserves the external-only storage behavior used by `store_jobstats.py`. Backfilling missed historical jobs into the external database is not currently supported by `ingest_jobstats`.
+
 Below is an example job summary for a GPU job:
 
 ```

--- a/slurm/ingest_jobstats
+++ b/slurm/ingest_jobstats
@@ -1,7 +1,20 @@
 #!/bin/bash
+
+external_db_enabled() {
+	local store_script jobstats_dir
+
+	store_script=$(readlink -f /usr/local/bin/store_jobstats.py 2>/dev/null) || return 1
+	jobstats_dir=$(dirname "$store_script")
+
+	JOBSTATS_DIR="$jobstats_dir" \
+		python3 -I -c 'import os, sys; sys.path.insert(0, os.environ["JOBSTATS_DIR"]); from config import EXTERNAL_DB_CONFIG; sys.exit(0 if EXTERNAL_DB_CONFIG.get("enabled", False) else 1)' \
+		>/dev/null 2>&1
+}
+
 help() {
 	echo "${0} -c CLUSTER [-d days] [-n maxjobs] [-v]"
 	echo "Check for jobs with no AdminComment set and try to fix it."
+	echo "When external DB storage is enabled, AdminComment backfill is skipped."
 	echo "It requires -c cluster option and can also accept number of days to look back with -d option and be verbose."
 	echo "E.g. ${0} -c speedy -d 100"
 }
@@ -33,6 +46,11 @@ done
 if [ -z "$CLUSTER" ]; then
 	echo "Please specify a cluster with -c option."
 	exit 1
+fi
+
+if external_db_enabled; then
+	echo "External database is enabled; skipping AdminComment backfill for cluster ${CLUSTER}."
+	exit 0
 fi
 
 for i in $(/usr/local/sbin/jobs_with_no_data.py -c $CLUSTER $DAYS $MAXJOBS); do

--- a/slurm/slurmctldepilog.sh
+++ b/slurm/slurmctldepilog.sh
@@ -19,7 +19,7 @@ if [ $ERR = 0 ]; then
 		# Check if external database storage is configured
 		if [ -f "/usr/local/bin/store_jobstats.py" ]; then
 			# Use external database storage only
-			OUT="`/usr/local/bin/store_jobstats.py --cluster=${SLURM_CLUSTER_NAME:-unknown} --jobid=$INTERNAL_JOBID --stats="JS1:$STATS" 2>&1`"
+			OUT="`/usr/local/bin/store_jobstats.py --cluster=${SLURM_CLUSTER_NAME:-unknown} --jobid=$SLURM_JOB_ID --stats="JS1:$STATS" 2>&1`"
 			if [ $? != 0 ]; then
 				logger "SlurmctldEpilog[$INTERNAL_JOBID]: External storage failed with $OUT"
 			else


### PR DESCRIPTION
This PR fixes two related issues in external DB mode.

The main fix is for array jobs. We were writing external DB rows using the array-style job ID like `1838_4`, but later `jobstats` looks jobs up using Slurm's raw `JobIDRaw`. Those do not line up, which is why array task lookup could fail. This changes the external DB write path to use `$SLURM_JOB_ID` instead, so it matches what `sacct` returns.

I also fixed `ingest_jobstats` so it does not try to backfill `AdminComment` when external MariaDB storage is enabled. In external DB mode, that backfill path is not really the right behavior, so it now exits cleanly instead.

I tested this on a test cluster with external db.

For the CPU array job, `sacct` showed:

```text
JobIDRaw|JobID|Elapsed|State|AdminComment
1841|1838_1|00:00:51|COMPLETED|
1842|1838_2|00:00:56|COMPLETED|
1843|1838_3|00:01:01|COMPLETED|
1838|1838_4|00:01:07|COMPLETED|
```

The important part there is that the last array task `1838_4` has `JobIDRaw=1838`, so that raw ID is what the external DB row needs to use.

The MariaDB rows for that same job were:

```text
id  cluster  jobid  prefix                    total_time  gpus  created_at
11  thunder  1841   JS1:Short                 NULL        NULL  2026-04-22 21:24:24
12  thunder  1842   JS1:Short                 NULL        NULL  2026-04-22 21:24:29
13  thunder  1843   JS1:H4sIAJM86WkC/1XMUQqA 61          0     2026-04-22 21:24:35
14  thunder  1838   JS1:H4sIAJg86WkC/6tWystP 67          0     2026-04-22 21:24:40
```

So this confirms the array tasks are now being stored under the raw Slurm IDs, including the last array element being stored as `1838` instead of `1838_4`.

I also verified that `AdminComment` stayed empty for the fresh test jobs:

```text
JobIDRaw|JobID|Elapsed|State|AdminComment
1837|1836_1|00:00:36|COMPLETED|
1844|1836_2|00:00:40|COMPLETED|
1836|1836_3|00:00:45|COMPLETED|
1841|1838_1|00:00:51|COMPLETED|
1842|1838_2|00:00:56|COMPLETED|
1843|1838_3|00:01:01|COMPLETED|
1838|1838_4|00:01:07|COMPLETED|
1839|1839|00:01:01|COMPLETED|
1840|1840|00:01:30|COMPLETED|
```

I also verified `jobstats` on fresh completed jobs, including:

- `jobstats 1840`
- `jobstats 1839`
- `jobstats 1838_3`

Example output for `jobstats 1838_3`:

```text
jobstats 1838_3

================================================================================
                              Slurm Job Statistics
================================================================================
         Job ID: 1838_3
   User/Account: root/root
       Job Name: jobstats-cpu-array
          State: COMPLETED
          Nodes: 1
      CPU Cores: 2
     CPU Memory: 1GB (500MB per CPU-core)
  QOS/Partition: normal/thunder
        Cluster: thunder
     Start Time: Wed Apr 22, 2026 at 4:23 PM
       Run Time: 00:01:01
     Time Limit: 00:03:00
...
```

This PR does not add support for backfilling missed historical jobs into the external database. In external DB mode, `ingest_jobstats` now skips the Slurm `AdminComment` backfill path rather than writing into the wrong store.
