### PR TITLE
jobstats.py: ensure self.end is integer

### DIFF
--- a/jobstats.py
+++ b/jobstats.py
@@ -253,7 +253,7 @@ class Jobstats:
 
         # currently running jobs will have Unknown as time
         if self.end == 'Unknown':
-            self.end = time.time()
+            self.end = int(time.time())
         else:
             if self.end.isnumeric():
                 self.end = int(self.end)


### PR DESCRIPTION
time.time() returns float, make sure self.end is always cast to integer