### PR TITLE
Fix GPU utilization output for MIG slices (fall back to nvidia_gpu_gr…

### DIFF
--- a/jobstats.py
+++ b/jobstats.py
@@ -390,9 +390,9 @@ class Jobstats:
                     self.get_data('gpu_used_memory', "max_over_time((nvidia_gpu_memory_used_bytes{{cluster='{cluster}'}} and nvidia_gpu_jobId == {jobid})[{diff}s:])")
             if not args or "gpu_utilization" in args:
                 if c.GPU_EXPORTER_JOBID:
-                    self.get_data('gpu_utilization', "avg_over_time(nvidia_gpu_duty_cycle{{cluster='{cluster}',jobid='{jobid}'}}[{diff}s:])")
+                    self.get_data('gpu_utilization', "avg_over_time((nvidia_gpu_duty_cycle{{cluster='{cluster}',jobid='{jobid}'}} or (nvidia_gpu_graphics_util_percent{{cluster='{cluster}',jobid='{jobid}'}} * 100))[{diff}s:])")
                 else:
-                    self.get_data('gpu_utilization', "avg_over_time((nvidia_gpu_duty_cycle{{cluster='{cluster}'}} and nvidia_gpu_jobId == {jobid})[{diff}s:])")
+                    self.get_data('gpu_utilization', "avg_over_time(((nvidia_gpu_duty_cycle{{cluster='{cluster}'}} or (nvidia_gpu_graphics_util_percent{{cluster='{cluster}'}} * 100)) and nvidia_gpu_jobId == {jobid})[{diff}s:])")
 
     def parse_stats(self):
         sp_node = self.sp_node


### PR DESCRIPTION
**Problem**                                                                                                                                                                                                                                                     
   
Running jobstats <JOB_ID> for a job that executed on a MIG slice prints:                                                                                                                                                                                    
GPU utilization  (Value is unknown)

**Fix**

The exporter already exposes a MIG-capable utilization metric via the GPM API: nvidia_gpu_graphics_util_percent (GPM_METRIC_GRAPHICS_UTIL). This metric is emitted per-MIG-slice on Hopper (H100) and newer hardware.

The query is changed to use **or** so it falls back to the GPM metric on MIG nodes while continuing to use nvidia_gpu_duty_cycle on non-MIG nodes.

Two details worth noting:

  - Unit alignment: the exporter stores GPM values divided by 100 (0–1 scale), while nvidia_gpu_duty_cycle is raw 0–100. Multiplying by 100 brings them to the same scale before the or.
  - Cluster filter placement: {cluster='...'} cannot be applied to a binary expression result in PromQL. Moving it to nvidia_gpu_jobId achieves the same filtering and matches on all common labels. Non-MIG behaviour is  unchanged.

**Compatibility**

  - Non-MIG nodes: nvidia_gpu_duty_cycle is still used (the or right-hand side is absent on those nodes).
  - MIG nodes on Hopper+: nvidia_gpu_graphics_util_percent is used.