### PR TITLE
fix: resolve store_jobstats.py real path for symlink installations

### DIFF
--- a/docs/setup/external-database.md
+++ b/docs/setup/external-database.md
@@ -115,11 +115,15 @@ password = your_password
 
 ### 4. Script Installation
 
-Copy the `store_jobstats.py` script to `/usr/local/bin/` on your Slurm controller:
+The `store_jobstats.py` script must be installed alongside the other Jobstats
+modules (`db_handler.py`, `config.py`) so that it can import them. Install it
+into the same directory and create a symlink in `/usr/local/bin/` so it is
+available on the `PATH`:
 
 ```bash
-sudo cp store_jobstats.py /usr/local/bin/
-sudo chmod +x /usr/local/bin/store_jobstats.py
+sudo cp store_jobstats.py /usr/local/jobstats/
+sudo chmod +x /usr/local/jobstats/store_jobstats.py
+sudo ln -s /usr/local/jobstats/store_jobstats.py /usr/local/bin/store_jobstats.py
 ```
 
 ### 5. Slurm Configuration

--- a/store_jobstats.py
+++ b/store_jobstats.py
@@ -7,8 +7,9 @@ try:
 except ImportError:
     MySQLdb = None
 
-# Add the parent directory to Python path to import jobstats modules
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# realpath resolve the script's real location when invoked through a symlink
+# (e.g. /usr/local/bin/store_jobstats.py -> /usr/local/jobstats/store_jobstats.py).
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
 from db_handler import JobstatsDBHandler
 from config import EXTERNAL_DB_CONFIG


### PR DESCRIPTION
@plazonic  thanks for your comments/feedback in #46  

The previous sys.path computation used os.path.abspath() and walked two directory levels up, which produces an incorrect path when the script lived in the jobstats package directory (e.g. /usr/local/jobstats).

Using os.path.realpath() resolves any symlink, so the recommended installation layout -- the script installed alongside db_handler.py and config.py under /usr/local/jobstats, with a symlink in /usr/local/bin -- works regardless of how the script is invoked.

Updated the external-database.md documentation to describe the new installation steps (install in the package directory, symlink to /usr/local/bin).