### PR TITLE
feat: optional mirroring of jobstats to AdminComment via sacctmgr

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,6 +8,10 @@ PROM_RETENTION_DAYS = 365
 
 # if using Slurm database then include the lines below with "enabled": False
 # if using MariaDB then set "enabled": True and uncomment "config_file"
+# Set "mirror_to_admin_comment": True to additionally write the JS1: payload
+# to the Slurm AdminComment field (sacctmgr). This preserves compatibility
+# with sacct-based tools such as reportseff which read GPU/multi-node
+# efficiency from AdminComment.
 EXTERNAL_DB_CONFIG = {
     "enabled": False,  # set to True to use the external db for storing stats
     "host": "127.0.0.1",
@@ -15,7 +19,8 @@ EXTERNAL_DB_CONFIG = {
     "database": "jobstats",
     "user": "jobstats",
     "password": "password",
-#     "config_file": "/path/to/jobstats-db.cnf"
+#     "config_file": "/path/to/jobstats-db.cnf",
+#     "mirror_to_admin_comment": False,  # also write JS1 payload to AdminComment via sacctmgr
 }
 
 # number of seconds between measurements

--- a/docs/setup/external-database.md
+++ b/docs/setup/external-database.md
@@ -136,6 +136,39 @@ Update your `slurmctldepilog.sh` script. The script will automatically detect th
 
 - **External DB enabled**: Job statistics are stored only in the external database
 - **External DB disabled**: Job statistics are stored in `AdminComment` in Slurm DB (default behavior)
+- **External DB enabled with `mirror_to_admin_comment: True`**: Job statistics are stored in the external database AND mirrored to `AdminComment` (see below)
+
+#### Mirroring to AdminComment for sacct-based tools
+
+Some tools, most notably [`reportseff`](https://github.com/troycomi/reportseff),
+read multi-node and GPU efficiency information directly from the Slurm
+`AdminComment` field as it is populated by Jobstats. When the external database
+is enabled, `AdminComment` is left empty by default and these tools cannot
+display GPU/multi-node statistics.
+
+To keep these tools working, set `mirror_to_admin_comment` in `EXTERNAL_DB_CONFIG`:
+
+```python
+EXTERNAL_DB_CONFIG = {
+    "enabled": True,
+    "database": "jobstats",
+    "config_file": "/etc/jobstats/mysql.cnf",
+    "mirror_to_admin_comment": True,
+}
+```
+
+When this flag is true, `store_jobstats.py` will, after a successful write to
+the external database, also invoke
+`sacctmgr -i update job where jobid=<jobid> set AdminComment=<stats>` to
+mirror the same payload to `AdminComment`. The mirroring step is best-effort:
+failures are logged to stderr but do not fail the script since the external
+DB write has already succeeded.
+
+| `enabled` | `mirror_to_admin_comment` | External DB | AdminComment |
+|---|---|---|---|
+| `False` | (any)   | not written | written by epilog (default behavior) |
+| `True`  | `False` | written     | not written (current behavior, unchanged) |
+| `True`  | `True`  | written     | written (mirrored, for `sacct`-based tools) |
 
 ### Epilog Script Logic
 

--- a/store_jobstats.py
+++ b/store_jobstats.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import subprocess
 import sys
 import os
 try:
@@ -23,6 +24,39 @@ def parse_jobid(value):
             f"Job ID must be a raw numeric Slurm job ID, got {value!r}"
         )
     return int(jobid)
+
+
+def mirror_to_admin_comment(jobid, stats):
+    """Mirror the JS1 payload to the Slurm AdminComment field via sacctmgr.
+
+    A failure here does not fail the script: the external database write has
+    already succeeded and AdminComment is a secondary, best-effort target
+    for sacct-based consumers (e.g. reportseff).
+    """
+    try:
+        result = subprocess.run(
+            ["sacctmgr", "-i", "update", "job",
+             f"jobid={jobid}", "set", f"AdminComment={stats}"],
+            capture_output=True, text=True, check=False,
+        )
+        if result.returncode != 0:
+            print(
+                f"WARNING: sacctmgr failed to mirror AdminComment for job "
+                f"{jobid} (rc={result.returncode}): "
+                f"{(result.stderr or result.stdout).strip()}",
+                file=sys.stderr,
+            )
+    except FileNotFoundError:
+        print(
+            "WARNING: sacctmgr not found; cannot mirror to AdminComment.",
+            file=sys.stderr,
+        )
+    except Exception as exc:
+        print(
+            f"WARNING: unexpected error while mirroring AdminComment for "
+            f"job {jobid}: {exc}",
+            file=sys.stderr,
+        )
 
 
 def main():
@@ -56,7 +90,13 @@ def main():
     if errors:
         print(f"Errors occurred: {'; '.join(errors)}", file=sys.stderr)
         sys.exit(1)
-    
+
+    # Optionally mirror the payload to AdminComment for sacct-based consumers
+    # (e.g. reportseff). Best-effort: failures are logged but do not fail the
+    # script because the external DB write has already succeeded.
+    if EXTERNAL_DB_CONFIG.get("mirror_to_admin_comment", False):
+        mirror_to_admin_comment(args.jobid, args.stats)
+
     print("Successfully stored jobstats")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add an optional 'mirror_to_admin_comment' key to EXTERNAL_DB_CONFIG. When True, `store_jobstats.py` mirrors the JS1 payload to the Slurm `AdminComment` field via `sacctmgr` after a successful external DB write.

This in order to preserve compatibility with sacct-based tools such as `reportseff`, which I understand, read multi-node and GPU efficiency information from Slurm `AdminComment` as populated by `Jobstats`. Without this flag, enabling the external database will silently breaks those tools' GPU efficiency columns.

Default value is False, preserving the current behavior. Mirroring failures are logged to stderr but do not fail the script because the external DB write -- the primary storage target -- has already succeeded.