### PR TITLE
fix: use BIGINT for external DB raw job ids

### DIFF
--- a/db_handler.py
+++ b/db_handler.py
@@ -17,6 +17,16 @@ class JobstatsDBHandler:
     def __init__(self):
         self.external_db_enabled = EXTERNAL_DB_CONFIG.get("enabled", False)
         self.external_conn = None
+
+    def _normalize_external_jobid(self, jobid):
+        """Return a raw Slurm job ID as an integer for external DB queries."""
+        jobid_str = str(jobid).strip()
+        if not jobid_str or not jobid_str.isdigit():
+            raise ValueError(
+                "External database job IDs must be raw numeric Slurm job IDs, "
+                f"got {jobid!r}"
+            )
+        return int(jobid_str)
         
     def get_external_connection(self):
         """Get connection to external MariaDB database"""
@@ -49,6 +59,7 @@ class JobstatsDBHandler:
             return None
             
         try:
+            normalized_jobid = self._normalize_external_jobid(jobid)
             conn = self.get_external_connection()
             cur = conn.cursor()
             
@@ -60,7 +71,7 @@ class JobstatsDBHandler:
             LIMIT 1
             """
             
-            cur.execute(query, (cluster, jobid))
+            cur.execute(query, (cluster, normalized_jobid))
             result = cur.fetchone()
             
             if result:
@@ -119,6 +130,7 @@ class JobstatsDBHandler:
     
     def _save_to_external_db(self, cluster, jobid, stats):
         """Save to external MariaDB database with structured tables"""
+        normalized_jobid = self._normalize_external_jobid(jobid)
         conn = self.get_external_connection()
         
         try:
@@ -146,13 +158,16 @@ class JobstatsDBHandler:
             gpus = VALUES(gpus),
             updated_at = NOW()
             """
-            cur.execute(summary_query, (cluster, jobid, stats, total_time, gpus))
+            cur.execute(summary_query, (cluster, normalized_jobid, stats, total_time, gpus))
             
             # Get the job_summary_id
             summary_id = cur.lastrowid
             if summary_id == 0:
                 # Row was updated, not inserted; fetch the ID
-                cur.execute(f"SELECT id FROM {EXTERNAL_DB_SUMMARY_TABLE} WHERE cluster = %s AND jobid = %s", (cluster, jobid))
+                cur.execute(
+                    f"SELECT id FROM {EXTERNAL_DB_SUMMARY_TABLE} WHERE cluster = %s AND jobid = %s",
+                    (cluster, normalized_jobid),
+                )
                 result = cur.fetchone()
                 if result:
                     summary_id = result[0]

--- a/docs/setup/external-database.md
+++ b/docs/setup/external-database.md
@@ -21,11 +21,11 @@ CREATE DATABASE jobstats;
 USE jobstats;
 
 -- Main job summary table
--- Note: cluster VARCHAR(40) respects Slurm's 40-character cluster name limit
+-- jobid stores the raw numeric Slurm job ID (JobIDRaw / SLURM_JOB_ID)
 CREATE TABLE job_summary (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     cluster VARCHAR(40) NOT NULL,
-    jobid VARCHAR(50) NOT NULL,
+    jobid BIGINT NOT NULL,
     admin_comment LONGTEXT,
     total_time DOUBLE DEFAULT NULL,
     gpus INT DEFAULT NULL,
@@ -170,6 +170,25 @@ From Slurm `AdminComment` to External DB:
 2. Install the `store_jobstats.py` script
 3. Future jobs will automatically use the external database
 
+From earlier structured external DB installs using `VARCHAR(50)` for `job_summary.jobid`:
+
+1. Confirm all stored job IDs are raw numeric Slurm IDs:
+
+```sql
+SELECT cluster, jobid
+FROM job_summary
+WHERE jobid REGEXP '[^0-9]';
+```
+
+2. If the query returns no rows, migrate the column to `BIGINT`:
+
+```sql
+ALTER TABLE job_summary
+MODIFY jobid BIGINT NOT NULL;
+```
+
+3. If the query returns rows, clean those rows first before applying the schema change.
+
 ## Ingest and Backfill
 
 When external database storage is enabled, `ingest_jobstats` backfills missing rows into the external database instead of writing `AdminComment` in the Slurm database. It does this by comparing completed jobs from Slurm accounting with the rows already present in `job_summary`, then processing only the jobs that are missing from the external database.
@@ -230,5 +249,7 @@ CREATE TABLE job_statistics (
     UNIQUE KEY unique_cluster_job (cluster, jobid)
 );
 ```
+
+This legacy schema used `VARCHAR(50)` for `jobid` because older versions could store non-raw identifiers such as array-style job IDs. The current structured schema uses `BIGINT` because it stores raw numeric Slurm job IDs.
 
 This schema stored all job metrics in a compressed blob in the `admin_comment` field. The new structured schema decodes and stores metrics in explicit columns for easier querying. The `admin_comment` field is retained in `job_summary` for backward compatibility.

--- a/store_jobstats.py
+++ b/store_jobstats.py
@@ -14,10 +14,26 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from db_handler import JobstatsDBHandler
 from config import EXTERNAL_DB_CONFIG
 
+
+def parse_jobid(value):
+    """Parse a raw numeric Slurm job ID for external DB storage."""
+    jobid = value.strip()
+    if not jobid or not jobid.isdigit():
+        raise argparse.ArgumentTypeError(
+            f"Job ID must be a raw numeric Slurm job ID, got {value!r}"
+        )
+    return int(jobid)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Store jobstats to external and/or Slurm database")
     parser.add_argument("--cluster", required=True, help="Cluster name")
-    parser.add_argument("--jobid", required=True, help="Job ID")
+    parser.add_argument(
+        "--jobid",
+        required=True,
+        type=parse_jobid,
+        help="Raw Slurm job ID",
+    )
     parser.add_argument("--stats", required=True, help="Job statistics")
     
     args = parser.parse_args()


### PR DESCRIPTION
Fixes external DB job ID handling by storing raw Slurm job IDs as BIGINT instead of VARCHAR. This also adds validation so only numeric raw job IDs are accepted, and updates the external database setup docs with migration guidance for older installs.