### PR TITLE
Use key-value iterators for convenience

### DIFF
--- a/jobstats.py
+++ b/jobstats.py
@@ -419,11 +419,10 @@ class Jobstats:
         total_cores = 0
         self.cpu_util_error_code = 0
         self.cpu_util__node_used_alloc_cores = []
-        for n in sp_node:
-            d = sp_node[n]
+        for n, d in sp_node.items():
             if 'total_time' in d and 'cpus' in d:
-                used  = sp_node[n]['total_time']
-                cores = sp_node[n]['cpus']
+                used  = d['total_time']
+                cores = d['cpus']
                 alloc = self.diff * cores
                 total += alloc
                 total_used += used
@@ -446,12 +445,11 @@ class Jobstats:
         total_cores = 0
         self.cpu_mem_error_code = 0
         self.cpu_mem__node_used_alloc_cores = []
-        for n in sp_node:
-            d = sp_node[n]
+        for n, d in sp_node.items():
             if 'used_memory' in d and 'total_memory' in d and 'cpus' in d:
-                used  = sp_node[n]['used_memory']
-                alloc = sp_node[n]['total_memory']
-                cores = sp_node[n]['cpus']
+                used  = d['used_memory']
+                alloc = d['total_memory']
+                cores = d['cpus']
                 total += alloc
                 total_used += used
                 total_cores += cores
@@ -473,8 +471,7 @@ class Jobstats:
             overall_gpu_count = 0
             self.gpu_util_error_code = 0
             self.gpu_util__node_util_index = []
-            for n in sp_node:
-                d = sp_node[n]
+            for n, d in sp_node.items():
                 if 'gpu_utilization' in d:
                     gpus = list(d['gpu_utilization'].keys())
                     gpus.sort()
@@ -497,8 +494,7 @@ class Jobstats:
             overall_total = 0
             self.gpu_mem_error_code = 0
             self.gpu_mem__node_used_total_index = []
-            for n in sp_node:
-                d = sp_node[n]
+            for n, d in sp_node.items():
                 if 'gpu_used_memory' in d and 'gpu_total_memory' in d:
                     gpus = list(d['gpu_total_memory'].keys())
                     gpus.sort()


### PR DESCRIPTION
This is hopefully a more convenient way to iterate Python dicts such as sp_nodes, which will grab the key and value together as pairs. With this method, there is also no need to lookup the value from the dict using the iterated key.